### PR TITLE
Slight Info.plist rename

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>ionicframework</string>
+	<string>ionic</string>
 	<key>CFBundleName</key>
-	<string>Ionic Framework</string>
+	<string>Ionic</string>
   <key>DocSetPlatformFamily</key>
   <string>ionic</string>
   <key>dashIndexFilePath</key>


### PR DESCRIPTION
Just call it "Ionic". I don't include stuff like "Framework", "Library", "API" for any of the other docsets so it should be fine to just call it "Ionic".
